### PR TITLE
Fix configuration example in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,127 +65,67 @@ The configuration file is expected in the YAML format, e.g.:
 
 [source,yaml]
 ----
-filername_1:
+filer:
     # name will be used in the filer label of the metrics. Mandatory
-    name: 'netapp_filer_1'
+    - name: 'netapp_filer_1'
 
-    # Name or address of filer. Mandatory
-    address: 'name.ip.or.fqdn'
+      # Name or address of filer. Mandatory
+      address: 'name.ip.or.fqdn'
 
-    # Path to CA certificate used for signing the fileservers HTTPS certificate. Optional
-    ca_cert: '/path/to/ca.crt'
+      # Path to CA certificate used for signing the fileservers HTTPS certificate. Optional
+      ca_cert: '/path/to/ca.crt'
 
-    # Skip verification of fileservers HTTPS certificate. Optional, default: false
-    insecure_ssl: false
+      # Skip verification of fileservers HTTPS certificate. Optional, default: false
+      insecure_ssl: false
 
-    # user name and passsword for authentication for accessing the REST API of the fileserver
-    user: 'reporting_user_name_on_filer'
-    password: 'ItsSoFluffyImGONNADIE!'
+      # user name and passsword for authentication for accessing the REST API of the fileserver
+      user: 'reporting_user_name_on_filer'
+      password: 'ItsSoFluffyImGONNADIE!'
 
-    # Connection timeout in seconds for fetching data from the REST API. Optional, default 0 (no timeout)
-    timeout: 120
+      # Connection timeout in seconds for fetching data from the REST API. Optional, default 0 (no timeout)
+      timeout: 120
 
-    # what data to fetch and export
-    targets:
-        # Aggregate statistics. Default: false
-        aggregates: true
+      # what data to fetch and export
+      targets:
+          # Aggregate statistics. Default: false
+          aggregates: true
 
-        # Chassis statistics. Note: Fetching chassis information is a *very* time consuming task. Default: false
-        chassis: false
+          # Chassis statistics. Note: Fetching chassis information is a *very* time consuming task. Default: false
+          chassis: false
 
-        # CIFS statistics. Note: Requires OnTap 9.8 or newer. Default: don't export CIFS statistics
-        cifs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
+          # CIFS statistics. Note: Requires OnTap 9.8 or newer. Default: don't export CIFS statistics
+          cifs:
+              # Export CIFS connection counters for client IPs. Default: false
+              client_ip: true
 
-            # Export user connections for mapped UNIX user. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            mapped_user: true
+              # Export user connections for mapped UNIX user. Default: false
+              # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
+              mapped_user: true
 
-            # Export user connections for Windows users. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            user: true
+              # Export user connections for Windows users. Default: false
+              # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
+              user: true
 
-        # Ethernet port statistics. Default: false
-        ethernet: true
+          # Ethernet port statistics. Default: false
+          ethernet: true
 
-        # Fibrechannel statistics. Default: false
-        fibrechannel: true
+          # Fibrechannel statistics. Default: false
+          fibrechannel: true
 
-        # Export counters for internal jobs on the fileserver. Default: false
-        jobs: true
+          # Export counters for internal jobs on the fileserver. Default: false
+          jobs: true
 
-        # Export NFS statistics. Default: don't export NFS statistics
-        nfs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
+          # Export NFS statistics. Default: don't export NFS statistics
+          nfs:
+              # Export CIFS connection counters for client IPs. Default: false
+              client_ip: true
 
-        # Export (user, group and tree) quota information. Default: false
-        quotas: true
+          # Export (user, group and tree) quota information. Default: false
+          quotas: true
 
-        # Export volume statistics. Default: false
-        volumes: true
+          # Export volume statistics. Default: false
+          volumes: true
 
-second_netapp_storage:
-    # name will be used in the filer label of the metrics. Mandatory
-    name: 'netapp_filer_2'
-
-    # Name or address of filer. Mandatory
-    address: 'name.ip.or.fqdn_2'
-
-    # Path to CA certificate used for signing the fileservers HTTPS certificate. Optional
-    ca_cert: '/path/to/ca.crt'
-
-    # Skip verification of fileservers HTTPS certificate. Optional, default: false
-    insecure_ssl: false
-
-    # user name and passsword for authentication for accessing the REST API of the fileserver
-    user: 'reporting_user_name_on_filer'
-    password: 'ItsSoFluffyImGONNADIE!'
-
-    # Connection timeout in seconds for fetching data from the REST API. Optional, default 0 (no timeout)
-    timeout: 120
-
-    # what data to fetch and export
-    targets:
-        # Aggregate statistics. Default: false
-        aggregates: true
-
-        # Chassis statistics. Note: Fetching chassis information is a *very* time consuming task. Default: false
-        chassis: false
-
-        # CIFS statistics. Note: Requires OnTap 9.8 or newer. Default: don't export CIFS statistics
-        cifs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
-
-            # Export user connections for mapped UNIX user. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            mapped_user: true
-
-            # Export user connections for Windows users. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            user: true
-
-        # Ethernet port statistics. Default: false
-        ethernet: true
-
-        # Fibrechannel statistics. Default: false
-        fibrechannel: true
-
-        # Export counters for internal jobs on the fileserver. Default: false
-        jobs: true
-
-        # Export NFS statistics. Default: don't export NFS statistics
-        nfs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
-
-        # Export (user, group and tree) quota information. Default: false
-        quotas: true
-
-        # Export volume statistics. Default: false
-        volumes: true
 ----
 
 === Exported metrics

--- a/doc/man/man1/prometheus-netapp-exporter.1
+++ b/doc/man/man1/prometheus-netapp-exporter.1
@@ -76,127 +76,67 @@ The configuration file is in YAML format. For example:
 
 .RS
 .nf
-filername_1:
-    # name will be used in the filer label of the metrics. Mandatory
-    name: 'netapp_filer_1'
+filer:
+    - # name will be used in the filer label of the metrics. Mandatory
+      name: 'netapp_filer_1'
 
-    # Name or address of filer. Mandatory
-    address: 'name.ip.or.fqdn'
+      # Name or address of filer. Mandatory
+      address: 'name.ip.or.fqdn'
 
-    # Path to CA certificate used for signing the fileservers HTTPS certificate. Optional
-    ca_cert: '/path/to/ca.crt'
+      # Path to CA certificate used for signing the fileservers HTTPS certificate. Optional
+      ca_cert: '/path/to/ca.crt'
 
-    # Skip verification of fileservers HTTPS certificate. Optional, default: false
-    insecure_ssl: false
+      # Skip verification of fileservers HTTPS certificate. Optional, default: false
+      insecure_ssl: false
 
-    # user name and passsword for authentication for accessing the REST API of the fileserver
-    user: 'reporting_user_name_on_filer'
-    password: 'ItsSoFluffyImGONNADIE!'
+      # user name and passsword for authentication for accessing the REST API of the fileserver
+      user: 'reporting_user_name_on_filer'
+      password: 'ItsSoFluffyImGONNADIE!'
 
-    # Connection timeout in seconds for fetching data from the REST API. Optional, default 0 (no timeout)
-    timeout: 120
+      # Connection timeout in seconds for fetching data from the REST API. Optional, default 0 (no timeout)
+      timeout: 120
 
-    # what data to fetch and export
-    targets:
-        # Aggregate statistics. Default: false
-        aggregates: true
+      # what data to fetch and export
+      targets:
+          # Aggregate statistics. Default: false
+          aggregates: true
 
-        # Chassis statistics. Note: Fetching chassis information is a *very* time consuming task. Default: false
-        chassis: false
+          # Chassis statistics. Note: Fetching chassis information is a *very* time consuming task. Default: false
+          chassis: false
 
-        # CIFS statistics. Note: Requires OnTap 9.8 or newer. Default: don't export CIFS statistics
-        cifs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
+          # CIFS statistics. Note: Requires OnTap 9.8 or newer. Default: don't export CIFS statistics
+          cifs:
+              # Export CIFS connection counters for client IPs. Default: false
+              client_ip: true
 
-            # Export user connections for mapped UNIX user. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            mapped_user: true
+              # Export user connections for mapped UNIX user. Default: false
+              # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
+              mapped_user: true
 
-            # Export user connections for Windows users. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            user: true
+              # Export user connections for Windows users. Default: false
+              # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
+              user: true
 
-        # Ethernet port statistics. Default: false
-        ethernet: true
+          # Ethernet port statistics. Default: false
+          ethernet: true
 
-        # Fibrechannel statistics. Default: false
-        fibrechannel: true
+          # Fibrechannel statistics. Default: false
+          fibrechannel: true
 
-        # Export counters for internal jobs on the fileserver. Default: false
-        jobs: true
+          # Export counters for internal jobs on the fileserver. Default: false
+          jobs: true
 
-        # Export NFS statistics. Default: don't export NFS statistics
-        nfs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
+          # Export NFS statistics. Default: don't export NFS statistics
+          nfs:
+              # Export CIFS connection counters for client IPs. Default: false
+              client_ip: true
 
-        # Export (user, group and tree) quota information. Default: false
-        quotas: true
+          # Export (user, group and tree) quota information. Default: false
+          quotas: true
 
-        # Export volume statistics. Default: false
-        volumes: true
+          # Export volume statistics. Default: false
+          volumes: true
 
-second_netapp_storage:
-    # name will be used in the filer label of the metrics. Mandatory
-    name: 'netapp_filer_2'
-
-    # Name or address of filer. Mandatory
-    address: 'name.ip.or.fqdn_2'
-
-    # Path to CA certificate used for signing the fileservers HTTPS certificate. Optional
-    ca_cert: '/path/to/ca.crt'
-
-    # Skip verification of fileservers HTTPS certificate. Optional, default: false
-    insecure_ssl: false
-
-    # user name and passsword for authentication for accessing the REST API of the fileserver
-    user: 'reporting_user_name_on_filer'
-    password: 'ItsSoFluffyImGONNADIE!'
-
-    # Connection timeout in seconds for fetching data from the REST API. Optional, default 0 (no timeout)
-    timeout: 120
-
-    # what data to fetch and export
-    targets:
-        # Aggregate statistics. Default: false
-        aggregates: true
-
-        # Chassis statistics. Note: Fetching chassis information is a *very* time consuming task. Default: false
-        chassis: false
-
-        # CIFS statistics. Note: Requires OnTap 9.8 or newer. Default: don't export CIFS statistics
-        cifs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
-
-            # Export user connections for mapped UNIX user. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            mapped_user: true
-
-            # Export user connections for Windows users. Default: false
-            # Note: This contains sensitive information and GDPR rules could prohibit collection of user names!
-            user: true
-
-        # Ethernet port statistics. Default: false
-        ethernet: true
-
-        # Fibrechannel statistics. Default: false
-        fibrechannel: true
-
-        # Export counters for internal jobs on the fileserver. Default: false
-        jobs: true
-
-        # Export NFS statistics. Default: don't export NFS statistics
-        nfs:
-            # Export CIFS connection counters for client IPs. Default: false
-            client_ip: true
-
-        # Export (user, group and tree) quota information. Default: false
-        quotas: true
-
-        # Export volume statistics. Default: false
-        volumes: true
 .fi
 .RE
 


### PR DESCRIPTION
Example configuration in the documentation does not reflecht the requirement.
`filer:` is mandatory (see `src/config.rs`) and storage servers are an array
